### PR TITLE
fix: submit triggered multiple time

### DIFF
--- a/src/context/ChatContext.jsx
+++ b/src/context/ChatContext.jsx
@@ -18,6 +18,7 @@ function ChatContextProvider({ children }) {
   } = useSocketContext();
   const [chatInfo, setChatInfo] = useLocalStorage('chat-app-chat-info', null);
   const [contacts, setContacts] = useState([]);
+  const [isMessageSending, setIsMessageSending] = useState(false);
 
   const { sendRequest: getUserContacts } = useAxios();
   const { sendRequest: updateReadStatus } = useAxios();
@@ -123,7 +124,9 @@ function ChatContextProvider({ children }) {
         handleChatSelect,
         updateContactLatestMessage,
         updateMessageStatusToRead,
-        fetchUserContacts
+        fetchUserContacts,
+        isMessageSending,
+        setIsMessageSending
       }}
     >
       {children}

--- a/src/hooks/useAxios.js
+++ b/src/hooks/useAxios.js
@@ -3,6 +3,7 @@ import { useAuthContext } from '../context/AuthContext';
 import axios from 'axios';
 import { authAPI } from '../api';
 import { errorToast } from '../utils/toastify';
+import { useChatContext } from '../context/ChatContext';
 
 const instance = axios.create({
   baseURL: process.env.VITE_SERVER_URL,
@@ -14,6 +15,8 @@ export const useAxios = () => {
 
   const [error, setError] = useState(null);
   const [isLoading, setIsLoading] = useState(false);
+
+  const { setIsMessageSending } = useChatContext();
 
   const refreshToken = useCallback(
     async (config, cb) => {
@@ -63,12 +66,13 @@ export const useAxios = () => {
           cb(result.data);
         }
       } catch (e) {
+        setIsMessageSending(false);
         e?.response?.status === 403 ? refreshToken(config, cb) : setError(e?.response?.data || e);
       } finally {
         setIsLoading(false);
       }
     },
-    [token, refreshToken]
+    [token, refreshToken, setIsMessageSending]
   );
 
   return { error, isLoading, sendRequest };

--- a/src/pages/Chat/ChatRoomInput.jsx
+++ b/src/pages/Chat/ChatRoomInput.jsx
@@ -15,7 +15,7 @@ function ChatRoomInput({ setChatMessages }) {
   const [showNotify, setShowNotify] = useState(false);
 
   const { user } = useAuthContext();
-  const { chatId, chatInfo, updateContactLatestMessage } = useChatContext();
+  const { chatId, chatInfo, updateContactLatestMessage, isMessageSending, setIsMessageSending } = useChatContext();
   const {
     socketValue: { socket, typingNotify }
   } = useSocketContext();
@@ -27,6 +27,7 @@ function ChatRoomInput({ setChatMessages }) {
       setInputMessage('');
       return;
     }
+    setIsMessageSending(true);
     postUserMessage(
       {
         method: 'POST',
@@ -60,6 +61,7 @@ function ChatRoomInput({ setChatMessages }) {
         });
 
         setInputMessage('');
+        setIsMessageSending(false);
       }
     );
   };
@@ -104,11 +106,11 @@ function ChatRoomInput({ setChatMessages }) {
             type="text"
             name="inputMessage"
             placeholder="Type something"
-            value={inputMessage}
+            value={isMessageSending ? '' : inputMessage}
             onChange={(e) => setInputMessage(e.target.value)}
             onKeyUp={handleKeyUp}
           />
-          <RoomInputButton>
+          <RoomInputButton disabled={isMessageSending}>
             <ButtonIconWrapper>
               <IoSend />
             </ButtonIconWrapper>

--- a/src/pages/Chat/ChatRoomMessage.jsx
+++ b/src/pages/Chat/ChatRoomMessage.jsx
@@ -5,15 +5,19 @@ import { useChatContext } from '../../context/ChatContext';
 import ChatMessage from '../Chat/ChatMessage';
 
 function ChatRoomMessage({ chatMessages, messageLoading }) {
-  const { chatId } = useChatContext();
+  const { chatId, isMessageSending } = useChatContext();
 
   const msgRef = useRef(null);
+  const sendingRef = useRef();
 
   useEffect(() => {
     if (msgRef.current) {
-      msgRef.current.scrollIntoView();
+      msgRef.current.scrollIntoView({ behavior: 'smooth' });
     }
-  }, [chatMessages]);
+    if (sendingRef.current) {
+      sendingRef.current.scrollIntoView({ behavior: 'smooth' });
+    }
+  }, [chatMessages, isMessageSending]);
 
   const renderedMessage = chatMessages.map((msg) => {
     return <ChatMessage key={msg._id} {...msg} ref={msgRef} />;
@@ -24,7 +28,7 @@ function ChatRoomMessage({ chatMessages, messageLoading }) {
       {chatId ? (
         messageLoading ? (
           <RoomEmptyMessage>Loading...</RoomEmptyMessage>
-        ) : chatMessages.length === 0 ? (
+        ) : chatMessages.length === 0 && !isMessageSending ? (
           <RoomEmptyMessage>Type to start chatting 🚀</RoomEmptyMessage>
         ) : (
           renderedMessage
@@ -32,6 +36,7 @@ function ChatRoomMessage({ chatMessages, messageLoading }) {
       ) : (
         <RoomWelcomeMessage>Select a user to start a chat</RoomWelcomeMessage>
       )}
+      {isMessageSending && <RoomSendingStatus ref={sendingRef}>Sending...</RoomSendingStatus>}
     </RoomMessage>
   );
 }
@@ -61,6 +66,13 @@ const RoomEmptyMessage = styled.div`
 
 const RoomWelcomeMessage = styled(RoomEmptyMessage)`
   font-size: 1.5rem;
+`;
+
+const RoomSendingStatus = styled.p`
+  text-align: center;
+  color: var(--primary);
+  font-size: 1rem;
+  font-weight: 500;
 `;
 
 export default ChatRoomMessage;


### PR DESCRIPTION
Problem:
Sometimes, when the API takes time to store a new message, the submit button can be triggered multiple times, resulting in the same message being sent repeatedly because the submit button is never disabled.

Solution:
To address this issue, we propose the following changes:

1. When a user sends a new message, a "Sending..." message will be displayed, indicating that the message is being processed.
2. The submit button will be disabled during this period to prevent the accidental submission of the same message.
3. Users will be able to see the message in "sending" mode, ensuring that they are aware of the ongoing process.